### PR TITLE
Fixed URL to the Arxiv paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ refer to https://github.com/bestfitting/instance_level_recognition
 
 ## Paper
 
-The solution is summarized in the paper `Efficient large-scale image retrieval with deep feature orthogonality and Hybrid-Swin-Transformers` which is available under https://arxiv.org/abs/2110.0378
+The solution is summarized in the paper `Efficient large-scale image retrieval with deep feature orthogonality and Hybrid-Swin-Transformers` which is available under https://arxiv.org/abs/2110.03786
 
 ## Citing
 


### PR DESCRIPTION
The url to the Arxiv paper "Efficient large-scale image retrieval with deep feature orthogonality and Hybrid-Swin-Transformers" is leading to another Arxiv paper titled "On the dynamics between gravity and entanglement". Added the correct [url](https://arxiv.org/abs/2110.03786) to the README.md.